### PR TITLE
add option to find files recursively for upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You will also need to provide the file or files being sent:
   * A glob; something like `file.txt`, `*.md`, or `**/*.pdf`
 * `file_path_recursive_match`
   * A Boolean; Find files recursively in subdirectories specified in `file_path`
-  * Defaults to 'false'
+  * Defaults to 'False'
 
 The following are optional and only needed to access sharepoint intances in different clouds (ie Soverign Clouds)
 The defaults provided will work for all other cases

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ You will also need to provide the file or files being sent:
 
 * `file_path`
   * A glob; something like `file.txt` or `*.md`
+* `file_path_recursive_match`
+  * A Boolean; Find files recursively in subdirectories specified in `file_path`
+  * Defaults to 'false'
 
 The following are optional and only needed to access sharepoint intances in different clouds (ie Soverign Clouds)
 The defaults provided will work for all other cases

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following will be provided to you by your Sharepoint administrator when you 
 You will also need to provide the file or files being sent:
 
 * `file_path`
-  * A glob; something like `file.txt` or `*.md`
+  * A glob; something like `file.txt`, `*.md`, or `**/*.pdf`
 * `file_path_recursive_match`
   * A Boolean; Find files recursively in subdirectories specified in `file_path`
   * Defaults to 'false'
@@ -51,7 +51,8 @@ jobs:
       - name: Send to Sharepoint
         uses: cringdahl/sharepoint-file-upload-action@1.0.0
         with:
-          file_path: "*.txt"
+          file_path: "**/*.txt"
+          file_path_recursive_match: False
           host_name: 'your.sharepoint.com'
           site_name: 'some_site'
           upload_path: 'fake_files'

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: 'Microsoft Graph API Endpoint (see README.md)'
     required: false
     default: "graph.microsoft.com"
+  file_path_recursive_match:
+    description: 'Find files recursively in subdirectories specified in file_path'
+    required: false
+    default: "false"
 outputs:
   return:
     description: 'Function output'
@@ -54,3 +58,4 @@ runs:
     - ${{ inputs.max_retries }}
     - ${{ inputs.login_endpoint }}
     - ${{ inputs.graph_endpoint }}
+    - ${{ inputs.file_path_recursive_match }}

--- a/src/send_to_sharepoint.py
+++ b/src/send_to_sharepoint.py
@@ -28,6 +28,10 @@ tenant_url = f'https://{sharepoint_host_name}/sites/{site_name}'
 # we're running this in actions, so we'll only ever have one .md file
 local_files = glob.glob(file_path, recursive=file_path_recursive_match)
 
+if not local_files:
+    print(f"[Error] No files matched pattern: {file_path}")
+    sys.exit(1)
+
 def acquire_token():
     """
     Acquire token via MSAL
@@ -55,7 +59,7 @@ def progress_status(offset, file_size):
     print(f"Uploaded {offset} bytes from {file_size} bytes ... {offset/file_size*100:.2f}%")
 
 def success_callback(remote_file):
-    print(f"File {remote_file.web_url} has been uploaded")
+    print(f"[✓]File {remote_file.web_url} has been uploaded")
 
 def resumable_upload(drive, local_path, file_size, chunk_size, max_chunk_retry, timeout_secs):
     def _start_upload():

--- a/src/send_to_sharepoint.py
+++ b/src/send_to_sharepoint.py
@@ -20,7 +20,7 @@ file_path = sys.argv[7]
 max_retry = int(sys.argv[8]) or 3
 login_endpoint = sys.argv[9] or "login.microsoftonline.com"
 graph_endpoint = sys.argv[10] or "graph.microsoft.com"
-file_path_recursive_match = sys.argv[11].lower() == 'true' if len(sys.argv) > 11 else False
+file_path_recursive_match = sys.argv[11] if len(sys.argv) > 11 and sys.argv[11] else "False"
 
 # below used with 'get_by_url' in GraphClient calls
 tenant_url = f'https://{sharepoint_host_name}/sites/{site_name}'

--- a/src/send_to_sharepoint.py
+++ b/src/send_to_sharepoint.py
@@ -20,12 +20,13 @@ file_path = sys.argv[7]
 max_retry = int(sys.argv[8]) or 3
 login_endpoint = sys.argv[9] or "login.microsoftonline.com"
 graph_endpoint = sys.argv[10] or "graph.microsoft.com"
+file_path_recursive_match = sys.argv[11].lower() == 'true' if len(sys.argv) > 11 else False
 
 # below used with 'get_by_url' in GraphClient calls
 tenant_url = f'https://{sharepoint_host_name}/sites/{site_name}'
 
 # we're running this in actions, so we'll only ever have one .md file
-local_files = glob.glob(file_path)
+local_files = glob.glob(file_path, recursive=file_path_recursive_match)
 
 def acquire_token():
     """


### PR DESCRIPTION
Hello, looking to contribute.  I am trying to upload files that are in multiple recursive directories to what is specified in `file_path`.  I see that pythons `blob.blob` supports a `recursive` argument and I'm using that here.  Leaving the default to false so there shouldn't be any breaking changes.

Appreciate your consideration.